### PR TITLE
Change webmock and vcr to development dependencies ID:1228

### DIFF
--- a/gman_client.gemspec
+++ b/gman_client.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'vcr', '3.0.1'
-  spec.add_runtime_dependency 'webmock', '1.22.6'
+  spec.add_development_dependency 'vcr', '3.0.1'
+  spec.add_development_dependency 'webmock', '1.22.6'
   spec.add_dependency 'blanket_wrapper', '3.0.2'
   spec.add_dependency 'hashie', '3.4.3'
   spec.add_dependency 'retries', '0.0.5'

--- a/lib/gman_client/version.rb
+++ b/lib/gman_client/version.rb
@@ -1,3 +1,3 @@
 module GmanClient
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end


### PR DESCRIPTION
https://westernmilling.tpondemand.com/entity/1228

Changing this to have vcr and webmock as a development dependency so it does affect the version of webmock and vcr for apps it's installed on.