### PR TITLE
Remove customer ids filter from bulk_contracts endpoint

### DIFF
--- a/lib/gman_client/commodity_merchandising/bulk_contracts.rb
+++ b/lib/gman_client/commodity_merchandising/bulk_contracts.rb
@@ -3,14 +3,14 @@
 module GmanClient
   module CommodityMerchandising
     module BulkContracts
-      def bulk_contracts(customer_ids)
+      def bulk_contracts
         response = attempt(@retry_attempts) do
           request
             .api
             .v1
             .commodity_merchandising
             .bulk_contracts
-            .get(params: { customer_ids: customer_ids.join(',') })
+            .get
         end
 
         response.map(&:to_h)

--- a/lib/gman_client/version.rb
+++ b/lib/gman_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GmanClient
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
We are unable to get all of the contracts needed with the
customer ids so removing the filter.

needed-by westernmilling/gman-services#107